### PR TITLE
Add .db.env to .gitignore to ignore sample Docker Compose secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ public/v1/js/webhooks
 resources/assets/v2/node_modules
 resources/assets/v2/build
 public/v2/i18n
+
+# ignore sample docker compose secrets
+.db.env


### PR DESCRIPTION
Changes in this pull request:

- Add .db.env to .gitignore to ignore sample Docker Compose secrets
